### PR TITLE
Count expiration index entries per row, not per moment

### DIFF
--- a/my-no-sql-core/src/db/db_partition/db_rows_container.rs
+++ b/my-no-sql-core/src/db/db_partition/db_rows_container.rs
@@ -69,17 +69,19 @@ impl DbRowsContainer {
 
     pub fn insert(&mut self, db_row: Arc<DbRow>) -> Option<Arc<DbRow>> {
         #[cfg(feature = "master-node")]
-        let added = self.rows_with_expiration_index.add(&db_row);
+        let inserted_db_row = db_row.clone();
 
         let (_, removed_db_row) = self.data.insert_or_replace(db_row);
 
+        // The replaced row has to leave the index before the new one enters it: when both share
+        // the expiration moment they share an index entry, and removing afterwards would drop it.
         #[cfg(feature = "master-node")]
-        if let Some(added) = added {
-            if added {
-                if let Some(removed_db_row) = &removed_db_row {
-                    self.rows_with_expiration_index.remove(removed_db_row);
-                }
+        {
+            if let Some(removed_db_row) = &removed_db_row {
+                self.rows_with_expiration_index.remove(removed_db_row);
             }
+
+            self.rows_with_expiration_index.add(&inserted_db_row);
         }
 
         removed_db_row
@@ -546,6 +548,56 @@ mod expiration_tests {
         db_rows.rows_with_expiration_index.assert_len(1);
 
         db_rows.remove("my-id");
+
+        db_rows.rows_with_expiration_index.assert_len(0);
+    }
+
+    fn insert_row(db_rows: &mut DbRowsContainer, row_key: &str, expires: &str) {
+        let row = format!(
+            r#"{{"PartitionKey":"client","RowKey":"{}","Expires":"{}"}}"#,
+            row_key, expires
+        );
+
+        let db_row = DbJsonEntity::parse_into_db_row(row.as_bytes().into(), &JsonTimeStamp::now())
+            .unwrap();
+
+        db_rows.insert(Arc::new(db_row));
+    }
+
+    /// A batch written in one go (as the trading-metrics-cache refresh timer does) shares a single
+    /// expiration moment, so every row of it lands in the same expiration index entry.
+    #[test]
+    fn rows_sharing_one_expiration_moment_are_counted_and_reindexed_per_row() {
+        const ROW_KEYS: [&str; 3] = ["a", "b", "c"];
+        const FIRST_EXPIRES: &str = "2030-01-01T00:00:00";
+        const SECOND_EXPIRES: &str = "2030-01-01T00:01:00";
+        const BETWEEN_EXPIRES: &str = "2030-01-01T00:00:30";
+
+        let mut db_rows = DbRowsContainer::new();
+
+        for row_key in ROW_KEYS {
+            insert_row(&mut db_rows, row_key, FIRST_EXPIRES);
+        }
+
+        db_rows.rows_with_expiration_index.assert_len(ROW_KEYS.len());
+
+        for row_key in ROW_KEYS {
+            insert_row(&mut db_rows, row_key, SECOND_EXPIRES);
+        }
+
+        db_rows.rows_with_expiration_index.assert_len(ROW_KEYS.len());
+
+        assert_eq!(
+            0,
+            db_rows
+                .get_rows_to_expire(DateTimeAsMicroseconds::from_str(BETWEEN_EXPIRES).unwrap())
+                .len(),
+            "rows re-written with a later Expires must not be left indexed at the old moment"
+        );
+
+        for row_key in ROW_KEYS {
+            db_rows.remove(row_key);
+        }
 
         db_rows.rows_with_expiration_index.assert_len(0);
     }

--- a/my-no-sql-core/src/expiration_index.rs
+++ b/my-no-sql-core/src/expiration_index.rs
@@ -21,9 +21,11 @@ impl<TOwnedType: Clone + ExpirationIndex<TOwnedType>> ExpirationIndexItem<TOwned
         }
     }
 
-    pub fn remove(&mut self, key_as_str: &str) -> bool {
+    /// Returns (whether the item was in here, whether no items are left).
+    pub fn remove(&mut self, key_as_str: &str) -> (bool, bool) {
+        let amount_before = self.items.len();
         self.items.retain(|f| f.get_id_as_str() != key_as_str);
-        self.items.is_empty()
+        (self.items.len() < amount_before, self.items.is_empty())
     }
 }
 
@@ -66,8 +68,8 @@ impl<TOwnedType: Clone + ExpirationIndex<TOwnedType>> ExpirationIndexContainer<T
                 {
                     false
                 } else {
-                    self.index[index].items.push(item.to_owned());
-                    false
+                    items.push(item.to_owned());
+                    true
                 }
             }
             Err(index) => {
@@ -112,10 +114,14 @@ impl<TOwnedType: Clone + ExpirationIndex<TOwnedType>> ExpirationIndexContainer<T
     fn do_remove(&mut self, expiration_moment: DateTimeAsMicroseconds, key_as_str: &str) {
         match self.find_index(expiration_moment) {
             Ok(index) => {
+                let mut removed = false;
                 let mut remove_index = None;
 
                 if let Some(items) = self.index.get_mut(index) {
-                    if items.remove(key_as_str) {
+                    let (item_removed, no_items_left) = items.remove(key_as_str);
+                    removed = item_removed;
+
+                    if no_items_left {
                         remove_index = Some(index);
                     }
                 }
@@ -124,7 +130,9 @@ impl<TOwnedType: Clone + ExpirationIndex<TOwnedType>> ExpirationIndexContainer<T
                     self.index.remove(remove_index);
                 }
 
-                self.amount -= 1;
+                if removed {
+                    self.amount -= 1;
+                }
             }
             Err(_) => {
                 #[cfg(not(test))]
@@ -174,6 +182,7 @@ impl<TOwnedType: Clone + ExpirationIndex<TOwnedType>> ExpirationIndexContainer<T
 
     pub fn clear(&mut self) {
         self.index.clear();
+        self.amount = 0;
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## The bug

`ExpirationIndexContainer` counted different things on the way in and on the way out.
`amount` was incremented only when an item created a **new expiration moment entry**, but
decremented for **every item removed**.

Rows written as a single batch share one expiration moment — that is exactly how the
my-prop-trading `trading-metrics-cache` refresh timer writes: `expire_date` is computed once
per tick and applied to the whole `bulk_insert_or_replace`. So a batch of N rows counted as
1 going in and N coming out, and `amount` wrapped around to `usize::MAX`. `/api/status` then
reported an `expirationIndex` of ~1.8e19, which the wasm32 UI cannot even parse into its
32-bit `usize` — the whole status page fails, not just that field.

Two smaller defects of the same kind: removal decremented unconditionally once the moment
entry was found, whether or not the key was actually in it, and `clear()` left `amount` behind.

## The more serious one

`DbRowsContainer::insert` dropped the replaced row's index entry only if the new row happened
to create a new moment entry. Re-writing a batch under a later `Expires` therefore left the
old entries indexed at the **old** moment. The GC deletes rows **by key**, so it kept removing
live rows well ahead of their real expiration, every cycle.

The replaced row now always leaves the index, and does so before the new one enters it: when
both share the expiration moment they share a single entry, so removing afterwards would
delete the entry the new row just got.

## Verification

`cargo test --features master-node` — 60/60 green, including a new regression test that walks
the batch-with-a-shared-moment path: insert N rows on one moment, re-write them on a later one,
check nothing is left indexed at the old moment, then remove them all.

## Note for release

Dependents pin this by git tag, so a tag (0.5.2) is needed for the fix to reach
`my-no-sql-server`. The UI-side counterpart, which makes the status page immune to a bogus
counter coming from an older server, is a separate PR against my-no-sql-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)